### PR TITLE
Add Splice(Q) and liftTypedFromUntypedSplice

### DIFF
--- a/tests/Language/Haskell/TH/Syntax/CompatSpec.hs
+++ b/tests/Language/Haskell/TH/Syntax/CompatSpec.hs
@@ -16,6 +16,10 @@ import Prelude.Compat
 
 import Test.Hspec
 
+#if MIN_VERSION_template_haskell(2,9,0)
+import Types
+#endif
+
 main :: IO ()
 main = hspec spec
 
@@ -38,6 +42,10 @@ spec = parallel $ do
   describe "IsCode" $
     it "manipulates typed TH expressions in a backwards-compatible way" $
       $$(fromCode (toCode [|| "abc" ||])) `shouldBe` "abc"
+
+  describe "liftTypedFromUntypedSplice" $
+    it "allows defining liftTyped in a convenient, backwards-compatible way" $
+      $$(liftTypedFromUntypedSplice MkFoo) `shouldBe` MkFoo
 #endif
 
 newtype PureQ a = MkPureQ (State Uniq a)

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Types (Foo(..)) where
+
+import Language.Haskell.TH.Syntax hiding (newName)
+#if MIN_VERSION_template_haskell(2,16,0)
+import Language.Haskell.TH.Syntax.Compat
+#endif
+
+data Foo = MkFoo deriving (Eq, Show)
+
+-- An example of how to use liftTypedFromUntypedSplice to minimize the amount
+-- of CPP one has to use when manually defining `liftTyped` in `Lift` instance.
+-- This example is contrived, since you could just as well derive this
+-- particular `Lift` instance, but the same template will carry over to `Lift`
+-- instances that cannot be derived.
+instance Lift Foo where
+  lift MkFoo = [| MkFoo |]
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = liftTypedFromUntypedSplice
+#endif

--- a/th-compat.cabal
+++ b/th-compat.cabal
@@ -54,6 +54,7 @@ test-suite spec
   type:                exitcode-stdio-1.0
   main-is:             Spec.hs
   other-modules:       Language.Haskell.TH.Syntax.CompatSpec
+                       Types
   build-depends:       base             >= 4.3 && < 5
                      , base-compat      >= 0.6 && < 0.12
                      , hspec            >= 2   && < 3


### PR DESCRIPTION
These are primarily useful for defining `liftTyped` manually without needing excessive amounts of CPP. See the Haddocks for `liftTypedFromUntypedSplice` for an example.

Progress towards #2.