### PR TITLE
Add unsafeSpliceCoerce

### DIFF
--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
+
+#if MIN_VERSION_template_haskell(2,16,0)
+{-# LANGUAGE UnliftedNewtypes #-}
+#endif
 module Types (Foo(..)) where
 
 import Language.Haskell.TH.Syntax hiding (newName)
+
 #if MIN_VERSION_template_haskell(2,16,0)
+import GHC.Exts (Int#)
 import Language.Haskell.TH.Syntax.Compat
 #endif
 
@@ -18,4 +25,17 @@ instance Lift Foo where
   lift MkFoo = [| MkFoo |]
 #if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = liftTypedFromUntypedSplice
+#endif
+
+#if MIN_VERSION_template_haskell(2,16,0)
+newtype UN = MkUN Int#
+
+-- An example of how to use unsafeSpliceCoerce to manually define liftTyped
+-- for an unlifted type in a backwards-compatible way. This example is
+-- contrived, since you could just as well derive this particular `Lift`
+-- instance, but the same template will carry over to `Lift` instances that
+-- cannot be derived.
+instance Lift UN where
+  lift (MkUN i#) = [| MkUN i# |]
+  liftTyped x = unsafeSpliceCoerce (lift x)
 #endif


### PR DESCRIPTION
This is one component used in `liftTypedFromUntypedSplice`. It is useful to have `unsafeSpliceCoerce` as its own function because while `liftTypedFromUntypedSplice` cannot be levity polymorphic (due to GHC restrictions), `unsafeSpliceCoerce` can be levity polymorphic. This makes `unsafeSpliceCoerce` useful for manully implementing `liftTyped` for unlifted `Lift` instances in a backwards compatible way. (See the `unsafeSpliceCoerce` Haddocks for an example of how to do this.)