### PR TITLE
Add docs and expToSplice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next [????.??.??]
 * Implement `qGetDoc` and `qPutDoc` in the `Quasi` instance for `QuoteToQuasi`.
+* Add `expToSplice`.
 
 ### 0.1.2 [2021.03.12]
 * Add `bindSplice`, `bindSplice_`, `examineSplice`, `joinSplice`,

--- a/README.md
+++ b/README.md
@@ -23,3 +23,61 @@ later), this module simply reexports `Quote` and `Code`
 from `Language.Haskell.TH.Syntax`. Refer to the Haddocks
 for `Language.Haskell.TH.Syntax.Compat` for examples of
 how to use this module.
+
+## Quick Start Guide
+
+Let's say you have a library that offers a `foo :: Q (TExp a)`
+and you want to make it compatible across this version.
+
+Use `SpliceQ` as a type alias for the return of your
+function instead. This is `Q (TExp a)` prior to GHC 9,
+and `Code Q a` after.  This allows your code to be spliced
+in regardless of GHC version.
+
+Use `liftSplice` to convert a `m (TExp a)` into a `Splice m a`.
+
+Use `examineSplice` before typed quoters. This will allow
+a typed quasiquotation to work regardless of GHC version.
+
+When splicing in a `TExp a` value into a typed quoter, use `expToSplice`.
+
+For a real life example, consider [this conversion, from this PR](https://github.com/parsonsmatt/discover-instances/pull/2):
+
+```haskell
+discoverInstances
+    :: forall (c :: _ -> Constraint) . (Typeable c)
+    => Q (TExp [SomeDict c])
+discoverInstances = do
+    let className = show (typeRep (Proxy @c))
+    instanceDecs <- reifyInstances (mkName className) [VarT (mkName "a")]
+
+    dicts <- fmap listTE $ traverse decToDict instanceDecs
+
+    [|| concat $$(pure dicts) ||]
+```
+
+With GHC 9, this will have the following problems:
+
+1. `reifyInstances` operates in `Q`, not `Code`, so it will not type check with the `[|| concat $$(pure dicts) ||]` line.
+2. We cannot call `pure` in `Code`, since `Code` is not an applicative.
+3. Typed quasiquotes return a `Quote m => Code m a`, not `Q (TExp a)`.
+
+To fix these problems, we make the following diff:
+
+```diff
+ discoverInstances
+     :: forall (c :: _ -> Constraint) . (Typeable c)
+-    => Q (TExp [SomeDict c])
++    => SpliceQ [SomeDic c]
+- discoverInstances = do
++ discoverInstances = liftSplice $ do
+     let className = show (typeRep (Proxy @c))
+     instanceDecs <- reifyInstances (mkName className) [VarT (mkName "a")]
+
+     dicts <- fmap listTE $ traverse decToDict instanceDecs
+
+-     [|| concat $$(pure dicts) ||]
++     liftSplice [|| concat $$(expToSplice dicts) ||]
+```
+
+The above pattern should work to ensure that code is compatible across a wide range of GHC versions.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To fix these problems, we make the following diff:
 
 ```diff
  discoverInstances
-     :: forall (c :: _ -> Constraint) . (Typeable c)
+     :: forall c. (Typeable c)
 -    => Q (TExp [SomeDict c])
 +    => SpliceQ [SomeDict c]
 - discoverInstances = do
@@ -83,7 +83,7 @@ To fix these problems, we make the following diff:
      dicts <- fmap listTE $ traverse decToDict instanceDecs
 
 -     [|| concat $$(pure dicts) ||]
-+     liftSplice [|| concat $$(expToSplice dicts) ||]
++     examineSplice [|| concat $$(expToSplice dicts) ||]
 ```
 
 The above pattern should work to ensure that code is compatible across a wide range of GHC versions.

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -788,7 +788,7 @@ bindSplice_ q c = liftSplice ( q >> examineSplice c)
 --
 -- @
 -- listTE :: ['Syntax.TExp' a] -> 'Syntax.TExp' [a]
--- listTE = 'Syntax.TExp' . 'ListE' . 'map' 'Syntax.unType'
+-- listTE = 'Syntax.TExp' . 'Syntax.ListE' . 'map' 'Syntax.unType'
 -- @
 --
 -- In a @do@ block using 'liftSplice', we can bind the resulting

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -773,7 +773,7 @@ bindSplice_ q c = liftSplice ( q >> examineSplice c)
 -- in the result of a computation into a typed QuasiQuoter.
 --
 -- @
--- foo :: 'SpliceQ' a
+-- foo :: 'SpliceQ' Int
 -- foo = 'liftSplice' $ do
 --      ints <- [|| [1,2,3] ||] :: SpliceQ [Int]
 --      'examineSplice' [|| sum $$(expToSplice ints) ||]

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -79,6 +79,7 @@ module Language.Haskell.TH.Syntax.Compat (
   , liftTypedFromUntypedSplice
   , unsafeSpliceCoerce
   , unTypeSplice
+  , expToSplice
 #endif
   ) where
 
@@ -767,6 +768,20 @@ bindSplice_ = bindCode_
 # else
 bindSplice_ q c = liftSplice ( q >> examineSplice c)
 # endif
+
+-- | Lift a @'Syntax.TExp' a@ into a 'Splice'. This is useful when splicing
+-- in the result of a computation into a typed QuasiQuoter.
+--
+-- @
+-- foo :: 'SpliceQ' a
+-- foo = 'liftSplice' $ do
+--      ints <- [|| [1,2,3] ||] :: SpliceQ [Int]
+--      'examineSplice' [|| sum $$(expToSplice ints) ||]
+-- @
+--
+-- @since ????.??.??
+expToSplice :: Applicative m => Syntax.TExp a -> Splice m a
+expToSplice a = liftSplice $ pure a
 
 -- | A variant of 'examineCode' that takes a 'Splice' as an argument. Because
 -- this function takes a 'Splice' as an argyment, the type of this function

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -68,6 +68,7 @@ module Language.Haskell.TH.Syntax.Compat (
   , joinCode
 
   -- * @Splice@
+  -- $splice
   , Splice
   , SpliceQ
   , bindSplice
@@ -768,6 +769,42 @@ bindSplice_ = bindCode_
 # else
 bindSplice_ q c = liftSplice ( q >> examineSplice c)
 # endif
+
+-- $splice
+--
+-- This section of code is useful for library authors looking to provide
+-- a typed @TemplateHaskell@ interface that is backwards- and
+-- forward-compatible. This section may be useful for you if you
+-- specifically intend for the splice to be done directly.
+--
+-- Prior to GHC 9, you'd offer a value with type @'Q' ('Syntax.TExp' a)@.
+-- After GHC 9, these values are no longer acceptable in a typed splice:
+-- typed splices must operate in @Code m a@ instead.
+--
+-- The @'Splice' m a@ type is used to work with both versions - it is a type
+-- alias, and depending on the version of @template-haskell@ that was
+-- compiled, it will either be @'Code' m a@ or @m ('Syntax.TExp' a)@.
+--
+-- The function 'liftSplice' can be used to convert a @'Q' ('Syntax.TExp' a)@
+-- expression into a @'Code' 'Q' a@ expression in a compatible manner - by
+-- lifting to 'SpliceQ', you get the right behavior depending on your
+-- @template-haskell@ version.
+--
+-- The function 'examineSplice' can be used on typed QuasiQuoters, and the
+-- result will be converted into an appropriate @m ('Syntax.TExp' a)@. This
+-- allows you to use typed quasiquoters in a @do@ block, much like
+-- 'examineCode' does with 'Code'.
+--
+-- With 'expToSplice', you can substitute uses of 'pure' when given the
+-- specific type:
+--
+-- @
+-- pureTExp :: 'Syntax.TExp' a -> 'Q' ('Syntax.TExp' a)
+-- pureTExp = pure
+-- @
+--
+-- This allows you to splice @'Syntax.TExp' a@ values directly into a typed
+-- quasiquoter.
 
 -- | Lift a @'Syntax.TExp' a@ into a 'Splice'. This is useful when splicing
 -- in the result of a computation into a typed QuasiQuoter.

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -67,7 +67,7 @@ module Language.Haskell.TH.Syntax.Compat (
   , bindCode_
   , joinCode
 
-  -- * Compatibity with @Splice@s
+  -- * Compatibility with @Splice@s
   -- $splice
   , Splice
   , SpliceQ

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -67,7 +67,7 @@ module Language.Haskell.TH.Syntax.Compat (
   , bindCode_
   , joinCode
 
-  -- * @Splice@
+  -- * Compatibity with @Splice@s
   -- $splice
   , Splice
   , SpliceQ


### PR DESCRIPTION
This PR adds some Quick Start docs, since it took me a while to figure out how to use the library.

I also added `expToSplice :: Applicative m => TExp a -> Splice m a`, which is useful when splicing in values, eg `let x :: TExp Int in [|| $(expToSplice x) :: Int ||]`.