### PR TITLE
Implement `qGetPackageRoot` in `Quasi` instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next [????.??.??]
+* Implement `qGetPackageRoot` in the `Quasi` instance for `QuoteToQuasi` when
+  building with `template-haskell-2.19.0.0` (GHC 9.4) or later.
+
 ### 0.1.3 [2021.08.29]
 * Implement `qGetDoc` and `qPutDoc` in the `Quasi` instance for `QuoteToQuasi`.
 * Add `expToSplice`.

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -447,6 +447,9 @@ instance Quote m => Quasi (QuoteToQuasi m) where
   qGetDoc             = qtqError "qGetDoc"
   qPutDoc             = qtqError "qPutDoc"
 #endif
+#if MIN_VERSION_template_haskell(2,19,0)
+  qGetPackageRoot     = qtqError "qGetPackageRoot"
+#endif
 
 -------------------------------------------------------------------------------
 -- Code

--- a/th-compat.cabal
+++ b/th-compat.cabal
@@ -42,7 +42,7 @@ source-repository head
 library
   exposed-modules:     Language.Haskell.TH.Syntax.Compat
   build-depends:       base             >= 4.3 && < 5
-                     , template-haskell >= 2.5 && < 2.19
+                     , template-haskell >= 2.5 && < 2.20
   if !impl(ghc >= 8.0)
     build-depends:     fail             == 4.9.*
                      , transformers     >= 0.2 && < 0.7
@@ -61,7 +61,7 @@ test-suite spec
                      , base-compat      >= 0.6 && < 0.13
                      , hspec            >= 2   && < 3
                      , mtl              >= 2.1 && < 2.4
-                     , template-haskell >= 2.5 && < 2.19
+                     , template-haskell >= 2.5 && < 2.20
                      , th-compat
   build-tool-depends:  hspec-discover:hspec-discover >= 2
   hs-source-dirs:      tests


### PR DESCRIPTION
`qGetPackageRoot` was added to `Quasi` in `template-haskell-2.19.0.0`, which is bundled with GHC 9.4.