### PR TITLE
Give standalone kind signatures to `Code`, `Splice`, `CodeQ`, and `SpliceQ`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,19 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241202
+# version: 0.19.20250917
 #
-# REGENDATA ("0.19.20241202",["github","cabal.project"])
+# REGENDATA ("0.19.20250917",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
+  - merge_group
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -28,14 +29,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.0.20241128
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241128
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.12.2
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -43,9 +44,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -102,30 +103,15 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -147,7 +133,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -175,18 +161,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -210,7 +184,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -235,14 +209,15 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_th_compat}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package th-compat" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package th-compat" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package th-compat" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           package th-compat
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-compat)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -29,6 +29,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250908
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250908
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -123,6 +128,21 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -133,7 +153,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -161,6 +181,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -218,6 +250,9 @@ jobs:
           package th-compat
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-compat)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -78,6 +78,7 @@ module Language.Haskell.TH.Syntax.Compat (
 
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.IO.Class (MonadIO(..))
+import Data.Kind (Type)
 import Language.Haskell.TH (Exp)
 import qualified Language.Haskell.TH.Lib as Lib ()
 import Language.Haskell.TH.Syntax (Q, runQ, Quasi(..))
@@ -373,7 +374,7 @@ unsafeQToQuote = unQTQ . runQ
 -- other method of 'Quasi' to be an error, since they cannot be implemented
 -- using 'Quote' alone. Similarly, its 'MonadFail' and 'MonadIO' instances
 -- define 'fail' and 'liftIO', respectively, to be errors.
-newtype QuoteToQuasi (m :: * -> *) a = QTQ { unQTQ :: m a }
+newtype QuoteToQuasi (m :: Type -> Type) a = QTQ { unQTQ :: m a }
   deriving (Functor, Applicative, Monad)
 
 qtqError :: String -> a
@@ -564,7 +565,7 @@ newtype Code m
 
 type CodeQ = Code Q
 #if MIN_VERSION_template_haskell(2,16,0)
-                    :: (TYPE r -> *)
+                    :: (TYPE r -> Type)
 #endif
 
 -- | Unsafely convert an untyped code representation into a typed code
@@ -719,9 +720,9 @@ joinCode = flip bindCode id
 --
 -- Levity-polymorphic since /template-haskell-2.16.0.0/.
 #if MIN_VERSION_template_haskell(2,22,0)
-type Splice  = Code :: ((* -> *) -> forall r. TYPE r -> *)
+type Splice  = Code :: ((Type -> Type) -> forall r. TYPE r -> Type)
 #elif MIN_VERSION_template_haskell(2,17,0)
-type Splice  = Code :: (forall r. (* -> *) -> TYPE r -> *)
+type Splice  = Code :: (forall r. (Type -> Type) -> TYPE r -> Type)
 #elif MIN_VERSION_template_haskell(2,16,0)
 type Splice m (a :: TYPE r) = m (Syntax.TExp a)
 #else
@@ -742,7 +743,7 @@ type Splice m a = m (Syntax.TExp a)
 --
 -- Levity-polymorphic since /template-haskell-2.16.0.0/.
 #if MIN_VERSION_template_haskell(2,17,0)
-type SpliceQ = Splice Q :: (TYPE r -> *)
+type SpliceQ = Splice Q :: (TYPE r -> Type)
 #elif MIN_VERSION_template_haskell(2,16,0)
 type SpliceQ (a :: TYPE r) = Splice Q a
 #else

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -564,9 +564,9 @@ newtype Code m
   }
 
 type CodeQ = Code Q
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
                     :: (TYPE r -> Type)
-#endif
+# endif
 
 -- | Unsafely convert an untyped code representation into a typed code
 -- representation.

--- a/src/Language/Haskell/TH/Syntax/Compat.hs
+++ b/src/Language/Haskell/TH/Syntax/Compat.hs
@@ -12,6 +12,10 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+#if __GLASGOW_HASKELL__ >= 810
+{-# LANGUAGE StandaloneKindSignatures #-}
+#endif
+
 -- | This module exists to make it possible to define code that works across
 -- a wide range of @template-haskell@ versions with as little CPP as possible.
 -- To that end, this module currently backports the following
@@ -552,6 +556,9 @@ instance texp ~ Syntax.TExp a => IsCode Q
 
 -- | Levity-polymorphic since /template-haskell-2.16.0.0/.
 #if !(MIN_VERSION_template_haskell(2,17,0))
+# if __GLASGOW_HASKELL__ >= 810
+type Code :: forall r. (Type -> Type) -> TYPE r -> Type
+# endif
 type role Code representational nominal
 newtype Code m
 # if MIN_VERSION_template_haskell(2,16,0)
@@ -563,6 +570,9 @@ newtype Code m
   { examineCode :: m (Syntax.TExp a) -- ^ Underlying monadic value
   }
 
+# if __GLASGOW_HASKELL__ >= 810
+type CodeQ :: TYPE r -> Type
+# endif
 type CodeQ = Code Q
 # if MIN_VERSION_template_haskell(2,16,0)
                     :: (TYPE r -> Type)
@@ -720,6 +730,11 @@ joinCode = flip bindCode id
 --
 -- Levity-polymorphic since /template-haskell-2.16.0.0/.
 #if MIN_VERSION_template_haskell(2,22,0)
+type Splice :: (Type -> Type) -> forall r. TYPE r -> Type
+#elif __GLASGOW_HASKELL__ >= 810
+type Splice :: forall r. (Type -> Type) -> TYPE r -> Type
+#endif
+#if MIN_VERSION_template_haskell(2,22,0)
 type Splice  = Code :: ((Type -> Type) -> forall r. TYPE r -> Type)
 #elif MIN_VERSION_template_haskell(2,17,0)
 type Splice  = Code :: (forall r. (Type -> Type) -> TYPE r -> Type)
@@ -742,8 +757,11 @@ type Splice m a = m (Syntax.TExp a)
 -- differ between @template-haskell@ versions as well.
 --
 -- Levity-polymorphic since /template-haskell-2.16.0.0/.
+#if __GLASGOW_HASKELL__ >= 810
+type SpliceQ :: TYPE r -> Type
+#endif
 #if MIN_VERSION_template_haskell(2,17,0)
-type SpliceQ = Splice Q :: (TYPE r -> Type)
+type SpliceQ = Splice Q
 #elif MIN_VERSION_template_haskell(2,16,0)
 type SpliceQ (a :: TYPE r) = Splice Q a
 #else

--- a/th-compat.cabal
+++ b/th-compat.cabal
@@ -29,10 +29,10 @@ tested-with:         GHC == 8.0.2
                    , GHC == 9.0.2
                    , GHC == 9.2.8
                    , GHC == 9.4.8
-                   , GHC == 9.6.6
+                   , GHC == 9.6.7
                    , GHC == 9.8.4
-                   , GHC == 9.10.1
-                   , GHC == 9.12.1
+                   , GHC == 9.10.3
+                   , GHC == 9.12.2
 extra-source-files:  CHANGELOG.md, README.md
 
 source-repository head

--- a/th-compat.cabal
+++ b/th-compat.cabal
@@ -33,6 +33,7 @@ tested-with:         GHC == 8.0.2
                    , GHC == 9.8.4
                    , GHC == 9.10.3
                    , GHC == 9.12.2
+                   , GHC == 9.14.1
 extra-source-files:  CHANGELOG.md, README.md
 
 source-repository head
@@ -42,7 +43,7 @@ source-repository head
 library
   exposed-modules:     Language.Haskell.TH.Syntax.Compat
   build-depends:       base             >= 4.9  && < 5
-                     , template-haskell >= 2.11 && < 2.24
+                     , template-haskell >= 2.11 && < 2.25
   if !impl(ghc >= 9.4)
     build-depends:     filepath         >= 1.2.0.0 && < 1.6
                      , directory        >= 1.1.0.0 && < 1.4
@@ -60,7 +61,7 @@ test-suite spec
   build-depends:       base             >= 4.9 && < 5
                      , hspec            >= 2   && < 3
                      , mtl              >= 2.1 && < 2.4
-                     , template-haskell >= 2.5 && < 2.24
+                     , template-haskell >= 2.5 && < 2.25
                      , th-compat
   build-tool-depends:  hspec-discover:hspec-discover >= 2
   hs-source-dirs:      tests


### PR DESCRIPTION
A side effect of performing this change is that this fixes an `-Wimplicit-rhs-quantification` warning in GHC 9.14. As such, this fixes https://github.com/haskell-compat/th-compat/issues/21.