### PR TITLE
Remove broken hackage-deps badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # `th-compat`
 [![Hackage](https://img.shields.io/hackage/v/th-compat.svg)][Hackage: th-compat]
-[![Hackage Dependencies](https://img.shields.io/hackage-deps/v/th-compat.svg)](http://packdeps.haskellers.com/reverse/th-compat)
 [![Haskell Programming Language](https://img.shields.io/badge/language-Haskell-blue.svg)][Haskell.org]
 [![BSD3 License](http://img.shields.io/badge/license-BSD3-brightgreen.svg)][tl;dr Legal: BSD3]
 [![Build Status](https://github.com/haskell-compat/th-compat/workflows/Haskell-CI/badge.svg)](https://github.com/haskell-compat/th-compat/actions?query=workflow%3AHaskell-CI)


### PR DESCRIPTION
It's deprecated for a long time: https://github.com/badges/shields/pull/10618